### PR TITLE
Fix blog header layout on mobile

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -60,6 +60,35 @@ $base-font-size: 18px;
   }
 }
 
+// Mobile header layout: Stack vertically
+.site-header {
+  @media screen and (max-width: 600px) {
+    .site-title {
+      float: none;
+      display: block;
+      text-align: center;
+      font-size: 22px;
+      line-height: 1.2;
+      padding: 15px 0 5px;
+    }
+
+    .site-nav {
+      float: none;
+      display: block;
+      text-align: center;
+      line-height: 1.2;
+      padding-bottom: 10px;
+
+      .page-link {
+        display: inline-block;
+        font-size: 14px;
+        margin: 0 8px !important;
+        padding: 8px 0;
+      }
+    }
+  }
+}
+
 img.center {
   display: block;
   margin-left: auto;

--- a/test-option-1.html
+++ b/test-option-1.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Option 1: Stack Vertically - Mobile Header Test</title>
+    <style>
+        /* Base styles */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+            font-weight: 300;
+            font-size: 18px;
+            color: #2e3440;
+            background-color: #eceff4;
+        }
+
+        /* Header styles */
+        .site-header {
+            min-height: 56px;
+            position: relative;
+            background-color: #e5e9f0;
+        }
+
+        .wrapper {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 15px;
+            overflow: hidden;
+        }
+
+        .site-title {
+            font-size: 26px;
+            font-weight: 300;
+            line-height: 56px;
+            letter-spacing: -1px;
+            margin-bottom: 0;
+            float: left;
+            color: #3b4252;
+            text-decoration: none;
+        }
+
+        .site-nav {
+            float: right;
+            line-height: 56px;
+        }
+
+        .site-nav .page-link {
+            color: #2e3440;
+            line-height: 1.5;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .site-nav .page-link:not(:last-child) {
+            margin-right: 20px;
+        }
+
+        /* OPTION 1: Stack Vertically on Mobile */
+        @media screen and (max-width: 600px) {
+            .site-header .site-title {
+                float: none;
+                display: block;
+                text-align: center;
+                font-size: 22px;
+                line-height: 1.2;
+                padding: 15px 0 5px;
+            }
+
+            .site-header .site-nav {
+                float: none;
+                display: block;
+                text-align: center;
+                line-height: 1.2;
+                padding-bottom: 10px;
+            }
+
+            .site-header .site-nav .page-link {
+                display: inline-block;
+                font-size: 14px;
+                margin: 0 8px !important;
+                padding: 8px 0;
+            }
+        }
+
+        /* Page content */
+        .page-content {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 0 15px;
+        }
+
+        .test-info {
+            background: #d8dee9;
+            padding: 20px;
+            margin-bottom: 20px;
+            border-radius: 4px;
+        }
+
+        .test-info h2 {
+            margin-bottom: 10px;
+            color: #2e3440;
+        }
+
+        .test-info ul {
+            margin-left: 20px;
+        }
+
+        .test-info li {
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <div class="wrapper">
+            <a class="site-title" href="/">on.code && such</a>
+            <nav class="site-nav">
+                <a class="page-link" href="/about/">About</a>
+                <a class="page-link" href="/categories/books">Book Reviews</a>
+                <a class="page-link" href="/categories/">Categories</a>
+                <a class="page-link" href="/archives/">Archives</a>
+            </nav>
+        </div>
+    </header>
+
+    <div class="page-content">
+        <div class="test-info">
+            <h2>Option 1: Stack Vertically</h2>
+            <p><strong>How it works:</strong></p>
+            <ul>
+                <li>Title and navigation stack vertically on mobile (≤600px)</li>
+                <li>Both elements are centered</li>
+                <li>Title font size reduced slightly (22px)</li>
+                <li>Navigation links displayed as inline blocks with even spacing</li>
+                <li>Link font size reduced to 14px for better fit</li>
+            </ul>
+            <p style="margin-top: 15px;"><strong>Testing:</strong></p>
+            <ul>
+                <li>✅ Resize your browser window to see the mobile layout</li>
+                <li>✅ Or open DevTools (F12) and toggle device toolbar</li>
+                <li>✅ Try widths: 320px (small phone), 375px (iPhone), 414px (large phone)</li>
+            </ul>
+            <p style="margin-top: 15px;"><strong>Pros:</strong> Clean, readable, large tap targets</p>
+            <p><strong>Cons:</strong> Uses more vertical space</p>
+        </div>
+
+        <h1>Sample Blog Content</h1>
+        <p>This is sample content to show how the page looks below the header. The header above demonstrates Option 1's vertical stacking approach for mobile screens.</p>
+    </div>
+</body>
+</html>

--- a/test-option-2.html
+++ b/test-option-2.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Option 2: Smaller Title + Compact Nav - Mobile Header Test</title>
+    <style>
+        /* Base styles */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+            font-weight: 300;
+            font-size: 18px;
+            color: #2e3440;
+            background-color: #eceff4;
+        }
+
+        /* Header styles */
+        .site-header {
+            min-height: 56px;
+            position: relative;
+            background-color: #e5e9f0;
+        }
+
+        .wrapper {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 15px;
+            overflow: hidden;
+        }
+
+        .site-title {
+            font-size: 26px;
+            font-weight: 300;
+            line-height: 56px;
+            letter-spacing: -1px;
+            margin-bottom: 0;
+            float: left;
+            color: #3b4252;
+            text-decoration: none;
+        }
+
+        .site-nav {
+            float: right;
+            line-height: 56px;
+        }
+
+        .site-nav .page-link {
+            color: #2e3440;
+            line-height: 1.5;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .site-nav .page-link:not(:last-child) {
+            margin-right: 20px;
+        }
+
+        /* OPTION 2: Smaller Title + Compact Nav on Mobile */
+        @media screen and (max-width: 600px) {
+            .site-header {
+                min-height: 48px;
+            }
+
+            .site-header .site-title {
+                font-size: 16px;
+                line-height: 48px;
+                letter-spacing: -0.5px;
+            }
+
+            .site-header .site-nav {
+                line-height: 48px;
+            }
+
+            .site-header .site-nav .page-link {
+                font-size: 12px;
+                margin-right: 8px !important;
+            }
+
+            .site-header .site-nav .page-link:not(:last-child) {
+                margin-right: 8px !important;
+            }
+        }
+
+        /* Page content */
+        .page-content {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 0 15px;
+        }
+
+        .test-info {
+            background: #d8dee9;
+            padding: 20px;
+            margin-bottom: 20px;
+            border-radius: 4px;
+        }
+
+        .test-info h2 {
+            margin-bottom: 10px;
+            color: #2e3440;
+        }
+
+        .test-info ul {
+            margin-left: 20px;
+        }
+
+        .test-info li {
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <div class="wrapper">
+            <a class="site-title" href="/">on.code && such</a>
+            <nav class="site-nav">
+                <a class="page-link" href="/about/">About</a>
+                <a class="page-link" href="/categories/books">Book Reviews</a>
+                <a class="page-link" href="/categories/">Categories</a>
+                <a class="page-link" href="/archives/">Archives</a>
+            </nav>
+        </div>
+    </header>
+
+    <div class="page-content">
+        <div class="test-info">
+            <h2>Option 2: Smaller Title + Compact Nav</h2>
+            <p><strong>How it works:</strong></p>
+            <ul>
+                <li>Maintains single-line horizontal layout on mobile (≤600px)</li>
+                <li>Title font size reduced to 16px</li>
+                <li>Navigation link font size reduced to 12px</li>
+                <li>Header height reduced to 48px</li>
+                <li>Spacing between links reduced to 8px</li>
+            </ul>
+            <p style="margin-top: 15px;"><strong>Testing:</strong></p>
+            <ul>
+                <li>✅ Resize your browser window to see the mobile layout</li>
+                <li>✅ Or open DevTools (F12) and toggle device toolbar</li>
+                <li>✅ Try widths: 320px (small phone), 375px (iPhone), 414px (large phone)</li>
+            </ul>
+            <p style="margin-top: 15px;"><strong>Pros:</strong> Compact, saves vertical space, familiar layout</p>
+            <p><strong>Cons:</strong> Text gets quite small, may be hard to read/tap on small screens</p>
+        </div>
+
+        <h1>Sample Blog Content</h1>
+        <p>This is sample content to show how the page looks below the header. The header above demonstrates Option 2's compact single-line approach for mobile screens.</p>
+    </div>
+</body>
+</html>

--- a/test-option-3.html
+++ b/test-option-3.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Option 3: Hide Some Links - Mobile Header Test</title>
+    <style>
+        /* Base styles */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+            font-weight: 300;
+            font-size: 18px;
+            color: #2e3440;
+            background-color: #eceff4;
+        }
+
+        /* Header styles */
+        .site-header {
+            min-height: 56px;
+            position: relative;
+            background-color: #e5e9f0;
+        }
+
+        .wrapper {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 15px;
+            overflow: hidden;
+        }
+
+        .site-title {
+            font-size: 26px;
+            font-weight: 300;
+            line-height: 56px;
+            letter-spacing: -1px;
+            margin-bottom: 0;
+            float: left;
+            color: #3b4252;
+            text-decoration: none;
+        }
+
+        .site-nav {
+            float: right;
+            line-height: 56px;
+        }
+
+        .site-nav .page-link {
+            color: #2e3440;
+            line-height: 1.5;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .site-nav .page-link:not(:last-child) {
+            margin-right: 20px;
+        }
+
+        /* OPTION 3: Hide Some Links + Stack on Mobile */
+        @media screen and (max-width: 600px) {
+            .site-header .site-title {
+                font-size: 18px;
+                line-height: 1.2;
+                padding: 12px 0 8px;
+                float: none;
+                text-align: center;
+                display: block;
+            }
+
+            .site-header .site-nav {
+                float: none;
+                text-align: center;
+                line-height: 1.2;
+                padding-bottom: 8px;
+            }
+
+            .site-header .site-nav .page-link {
+                font-size: 14px;
+                padding: 8px 10px;
+            }
+
+            /* Hide less important links on very small screens */
+            .site-header .site-nav .page-link:nth-child(n+3) {
+                display: none;
+            }
+        }
+
+        /* Show all links on slightly larger mobile screens */
+        @media screen and (min-width: 450px) and (max-width: 600px) {
+            .site-header .site-nav .page-link:nth-child(n+3) {
+                display: inline-block;
+            }
+        }
+
+        /* Page content */
+        .page-content {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 0 15px;
+        }
+
+        .test-info {
+            background: #d8dee9;
+            padding: 20px;
+            margin-bottom: 20px;
+            border-radius: 4px;
+        }
+
+        .test-info h2 {
+            margin-bottom: 10px;
+            color: #2e3440;
+        }
+
+        .test-info ul {
+            margin-left: 20px;
+        }
+
+        .test-info li {
+            margin: 5px 0;
+        }
+
+        .breakpoint-indicator {
+            background: #5e81ac;
+            color: white;
+            padding: 10px;
+            text-align: center;
+            margin-bottom: 20px;
+            border-radius: 4px;
+            font-weight: 600;
+        }
+
+        @media screen and (max-width: 449px) {
+            .breakpoint-indicator::before {
+                content: "📱 Very Small Phone (<450px) - Showing: About, Book Reviews only";
+            }
+        }
+
+        @media screen and (min-width: 450px) and (max-width: 600px) {
+            .breakpoint-indicator::before {
+                content: "📱 Larger Phone (450px-600px) - Showing: All links";
+            }
+        }
+
+        @media screen and (min-width: 601px) {
+            .breakpoint-indicator::before {
+                content: "💻 Desktop (>600px) - Normal layout";
+            }
+        }
+    </style>
+</head>
+<body>
+    <header class="site-header">
+        <div class="wrapper">
+            <a class="site-title" href="/">on.code && such</a>
+            <nav class="site-nav">
+                <a class="page-link" href="/about/">About</a>
+                <a class="page-link" href="/categories/books">Book Reviews</a>
+                <a class="page-link" href="/categories/">Categories</a>
+                <a class="page-link" href="/archives/">Archives</a>
+            </nav>
+        </div>
+    </header>
+
+    <div class="page-content">
+        <div class="breakpoint-indicator"></div>
+
+        <div class="test-info">
+            <h2>Option 3: Hide Some Links (Progressive Disclosure)</h2>
+            <p><strong>How it works:</strong></p>
+            <ul>
+                <li>Stacks title and navigation vertically on mobile (≤600px)</li>
+                <li>On very small screens (&lt;450px): Shows only "About" and "Book Reviews"</li>
+                <li>On larger phones (450-600px): Shows all navigation links</li>
+                <li>Title font size reduced to 18px</li>
+                <li>Navigation links at 14px</li>
+            </ul>
+            <p style="margin-top: 15px;"><strong>Testing:</strong></p>
+            <ul>
+                <li>✅ Resize your browser window to see the mobile layout</li>
+                <li>✅ Or open DevTools (F12) and toggle device toolbar</li>
+                <li>✅ Try widths: 320px (Categories/Archives hidden), 450px+ (all links shown)</li>
+                <li>✅ Watch the blue indicator bar above to see current breakpoint</li>
+            </ul>
+            <p style="margin-top: 15px;"><strong>Pros:</strong> Clean, focuses on essential navigation, adapts to screen size</p>
+            <p><strong>Cons:</strong> Some links hidden on very small screens (users can still access via other means)</p>
+        </div>
+
+        <h1>Sample Blog Content</h1>
+        <p>This is sample content to show how the page looks below the header. The header above demonstrates Option 3's progressive disclosure approach, hiding less critical links on very small screens.</p>
+
+        <p style="margin-top: 15px;"><em>Note: "Categories" and "Archives" are hidden on screens smaller than 450px, but "About" and "Book Reviews" (the most important links) remain visible.</em></p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Created three standalone test pages to demonstrate different approaches for fixing the mobile header layout issue:

- Option 1: Stack title and nav vertically (centered, clean)
- Option 2: Shrink fonts to keep single-line layout (compact)
- Option 3: Progressive disclosure (hide some links on small screens)

All solutions use pure CSS with no JavaScript.